### PR TITLE
Filter expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,7 @@ following template will output an array with exactly two items:
     having an `"$each"` instruction. `"$each"` defines a JsonPath query to
     find the input values.  The remaining keys in the item describe a
     "prototype" of the objects in the array.  One output object will be created
-    for each JsonPath query result on the input document. (There's a bug in the
-    current implementation preventing the ability to flatten embedded arrays:
-    only the last `[*]` is used so only the innermost array is "spread".)
+    for each JsonPath query result on the input document.
 5.  Conditional output can be achieved for many cases with the `"$exists"`
     instruction. The value of `"$exists"` is a JsonPath query.  If the query
     finds any matching value(s) in the input document, the entire template
@@ -197,14 +195,11 @@ following template will output an array with exactly two items:
 1.  Detect more developer errors.  Specifically, the code to detect `"$"` keys
     in templates does not detect unknown keys or incorrect mixture of keys with
     non-keys.
-2.  JsonPath allows the input document arrays to be filtered via simple
-    [expressions](http://goessner.net/articles/JsonPath/index.html#e3).  
-    This could be valuable.  It's currently only supported in `"$path"`.
-3.  JsonPath allows "scoped" queries via a leading `"@"` instead of a leading
+2.  JsonPath allows "scoped" queries via a leading `"@"` instead of a leading
     `"$"` in queries.  This would make templates easier to read and refactor.
     For example, under a query of `"$.foo"` in a template, a scoped query of
     `"@.bar"` would resolve to `"$.foo.bar"`.
-4.  Add a `"$comment"` instruction.
+3.  Add a `"$comment"` instruction.
 
 ### Built-in functions
 

--- a/evaluate.js
+++ b/evaluate.js
@@ -26,7 +26,7 @@ module.exports.evaluate
         }
         return undefined;
       } catch (e) {
-        e.message += ` -- JsonPath = ${path}`;
+        e.message += ` -- Json Template Path = "${path}"`;
         throw e;
       }
     };

--- a/evaluate.js
+++ b/evaluate.js
@@ -82,9 +82,10 @@ const explodeArrayTemplate =
 // Creates a template fragment whose queries are restricted to specific path.
 const rewriteFragment =
   protoype => (path) => {
-    const wildcard =
-      path.replace(/\[\d+\]/g, '[*]').replace(/(\$|\[|\*|\]|\.)/g, '\\$1');
-    const replacer = new RegExp(`"${wildcard}(.*?)"`, 'g');
+    const prefix = path
+      .replace(/^(.*)\[\d+\]/, '$1[*]') // replace last index with a wildcard
+      .replace(/(\$|\[|\*|\]|\.)/g, '\\$1'); // encode for regexp
+    const replacer = new RegExp(`"${prefix}(.*?)"`, 'g');
     const strFragment = protoype.replace(replacer, `"${path}$1"`);
 
     return JSON.parse(strFragment);

--- a/evaluate.js
+++ b/evaluate.js
@@ -63,43 +63,31 @@ const jsonPathValue =
 // discovered in the document.
 const explodeArrayTemplate =
   jsonpath => (doc, node) => {
-    // Extract sub-template and which array to explode
-    const subTemplate = node[0];
-    const [scope, nthArray] = subTemplate.$each.split(',');
+    // Extract sub-template
+    const subTemplate = jsonClone(node[0]);
+    const scope = subTemplate.$each;
+    delete subTemplate.$each;
+    const strTemplate = JSON.stringify(subTemplate);
 
-    const count = jsonpath.query(doc, scope).length;
-    const fragments = rewriteFragments(subTemplate, scope, nthArray, count);
+    // Run query to get selected (possibly filtered) nodes
+    const paths =
+      jsonpath.paths(doc, scope).map(path => jsonpath.stringify(path));
+
+    // For each path, create a new template fragment
+    const fragments = paths.map(rewriteFragment(strTemplate));
 
     return { node: fragments };
   };
 
-// Rewrites the new template fragments created when exploding an array.
-// The jsonpath queries within these fragments are more specific,
-// e.g. `Arr[0]` through `Arr[7]` instead of `Arr[*]`.
-// TODO: this doesn't work right when traversing several embedded arrays at once.
-const rewriteFragments =
-  (subTemplate, scope, nthArray, length) => {
-    // TODO: Don't assume selector is [*], allow filters like [?(@Mass)]
-    const parts = scope.split(/\[\*\]/g);
-    const pos = typeof nthArray !== 'undefined' ? nthArray : parts.length - 1;
-    const fragmentTemplate = JSON.stringify(subTemplate);
-    const replacer = new RegExp(scope.replace(/(\$|\*|\[|\])/g, '\\$1'), 'g');
-    const $scopeTemplate =
-      parts.slice(1).reduce(
-        (s, part, i) => s.concat(i + 1 === pos ? '[{{i}}]' : '[*]', part),
-        parts[0]
-      );
+// Creates a template fragment whose queries are restricted to specific path.
+const rewriteFragment =
+  protoype => (path) => {
+    const wildcard =
+      path.replace(/\[\d+\]/g, '[*]').replace(/(\$|\[|\*|\]|\.)/g, '\\$1');
+    const replacer = new RegExp(`"${wildcard}(.*?)"`, 'g');
+    const strFragment = protoype.replace(replacer, `"${path}$1"`);
 
-    // Re-write the scope for each new doc fragment
-    // TODO: [re]implement $scope so we don't have to rewrite the template?
-    return Array.from({ length }).map(
-        (_, i) => {
-          const $scope = $scopeTemplate.replace('[{{i}}]', `[${i}]`);
-          const frag = JSON.parse(fragmentTemplate.replace(replacer, $scope));
-          delete frag.$each;
-          return frag;
-        }
-      );
+    return JSON.parse(strFragment);
   };
 
 const isOptionalSubTemplate =

--- a/test/unit/expectedOutput.json
+++ b/test/unit/expectedOutput.json
@@ -1,7 +1,4 @@
 {
-  "TODO": [
-    "output an array from a query producing a single source value"
-  ],
   "object": {
     "constant": "this is constant",
     "simple": "vonnegut",
@@ -56,8 +53,17 @@
       ]
     }
   ],
+  "array_filter_expression": [
+    { "names": "granfalloons 1\n" },
+    { "names": "granfalloons 42\n" }
+  ],
+  "array_slice_expression": [
+    { "id": 1 },
+    { "id": 2 }
+  ],
   "array_not_spread": ["vonnegut"],
   "arrayOfValues": ["Hello, Star Vega", "Torture and Blubber", "Science Fiction"],
+  "arrayOfValues2": ["granfalloons 1\n", "granfalloons 42\n", "granfalloons 2\n"],
   "firstValue": "Hello, Star Vega",
   "lastValue": "Science Fiction",
   "cantFindThis": null

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -44,9 +44,6 @@ describe('jsonTransform', () => {
       .then(result => assert.deepEqual(result, expected));
   });
 
-  // See rewriteFragments function.  It doesn't currently work.
-  it('should allow array functionality to aggregate several levels at once');
-
   it('should throw if unknown instructions are found');
 
   it('should throw if invalid combos of instructions are found');

--- a/test/unit/sampleTemplate.json
+++ b/test/unit/sampleTemplate.json
@@ -1,7 +1,4 @@
 {
-  "TODO": [
-    "output an array from a query producing a single source value"
-  ],
   "object": {
     "constant": "this is constant",
     "simple": "$.id",
@@ -31,8 +28,21 @@
       ]
     }
   ],
+  "array_filter_expression": [
+    {
+      "$each": "$.wampeters[?(@.name!='Science Fiction')]",
+      "names": "$.wampeters[*].foma[*].name"
+    }
+  ],
+  "array_slice_expression": [
+    {
+      "$each": "$.wampeters[0:3:2]",
+      "id": "$.wampeters[*].id"
+    }
+  ],
   "array_not_spread": [{ "$path": "$.id" }],
   "arrayOfValues": "$.wampeters[*].name",
+  "arrayOfValues2": "$.wampeters[*].foma[*].name",
   "firstValue": "$.wampeters[0].name",
   "lastValue": "$.wampeters[-1:].name",
   "cantFindThis": "$.this.does.not.exist"


### PR DESCRIPTION
Allows jsonpath filter and slice expressions when specifying array template sections.  Examples:


$..book[(@.length-1)] | The last book via script subscript
$..book[-1:] | The last book via slice
$..book[0,1] | The first two books via subscript union
$..book[:2] | The first two books via subscript array slice
$..book[?(@.isbn)] | Filter all books with isbn number
$..book[?(@.price<10)] | Filter all books cheaper than 10
$..book[?(@.price==8.95)] | Filter all books that cost 8.95
$..book[?(@.price<30 && @.category=="fiction")]
