### PR TITLE
Properly guess author's intention wrt to outputting scalar or array. Fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ output format.  The input format can be completely different from the output.
 
 > TODO: more examples!!!
 
+> Hint: there are even more examples in the tests.
+
 The following template takes an input document's array of objects
 (`some_array_in_input`) and outputs a transformed array of objects.  The
 `"$each"` key instructs the transformer how to find the array in the input
@@ -171,21 +173,28 @@ following template will output an array with exactly two items:
 ### Notable features
 
 1.  Output values are computed via
-    [JsonPath](http://goessner.net/articles/JsonPath/) queries.  
-2.  Values can be computed via strings (like `"id": "$.ID"`) or via an object
+    [JsonPath](http://goessner.net/articles/JsonPath/) queries.
+2.  Queries are interpreted to determine whether the author intends to output a
+    single value ("scalar") or an array of values.  A query such as `"$.foo[*]"`
+    is clearly an array, but `"$.foo[0]"`, `"$.foo.bar"`, and `"$.foo['bar']"`
+    are for a single value.  The special case, `"$.foo[-1:]"` (a subscript
+    slice to fetch the last item), also returns a single value. _All other
+    subscript slices and expressions return an array of values._ For instance,
+    `"$.foo[(@.length-1)]"` returns an _array_ containing the last item.
+3.  Values can be computed via strings (like `"id": "$.ID"`) or via an object
     containing a `"$path"` instruction and further instructions (such as
     `"$map"`).  The value of the `"$path"` instruction is a JsonPath query used
     to query the document.
-3.  The `"$map"` instruction indicates that the associated value should be
+4.  The `"$map"` instruction indicates that the associated value should be
     transformed via a mapping function.  There are several built-in functions.
     (See the [Built-in functions](#built-in-functions))  You can extend these
     mapping functions by overriding/extending the built-in functions object.
-4.  Arrays of objects are defined via an array that must have _exactly_ one item
+5.  Arrays of objects are defined via an array that must have _exactly_ one item
     having an `"$each"` instruction. `"$each"` defines a JsonPath query to
     find the input values.  The remaining keys in the item describe a
     "prototype" of the objects in the array.  One output object will be created
-    for each JsonPath query result on the input document.
-5.  Conditional output can be achieved for many cases with the `"$exists"`
+    from the prototype for each JsonPath query result on the input document.
+6.  Conditional output can be achieved for many cases with the `"$exists"`
     instruction. The value of `"$exists"` is a JsonPath query.  If the query
     finds any matching value(s) in the input document, the entire template
     object is used.  Otherwise, it is omitted.
@@ -199,7 +208,7 @@ following template will output an array with exactly two items:
     `"$"` in queries.  This would make templates easier to read and refactor.
     For example, under a query of `"$.foo"` in a template, a scoped query of
     `"@.bar"` would resolve to `"$.foo.bar"`.
-3.  Add a `"$comment"` instruction.
+3.  Add a `"$comment"` instruction that doesn't get output.
 
 ### Built-in functions
 

--- a/test/unit/expectedOutput.json
+++ b/test/unit/expectedOutput.json
@@ -54,8 +54,8 @@
     }
   ],
   "array_filter_expression": [
-    { "names": "granfalloons 1\n" },
-    { "names": "granfalloons 42\n" }
+    { "names": ["granfalloons 1\n"] },
+    { "names": ["granfalloons 42\n"] }
   ],
   "array_slice_expression": [
     { "id": 1 },

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -47,4 +47,19 @@ describe('jsonTransform', () => {
   it('should throw if unknown instructions are found');
 
   it('should throw if invalid combos of instructions are found');
+
+  it('should guess if author intended array or value', () => {
+    assert.deepEqual(jsonTransform({ x: '$.foo' })({ foo: [ {} ] }), { x: [ {} ] }, 'extract array');
+    assert.deepEqual(jsonTransform({ x : '$.foo[*]' })({ foo: [ {} ] }), { x: [ {} ] }, 'extract an array\'s items');
+    assert.deepEqual(jsonTransform({ x: '$.foo' })({ foo: {} }), { x: {} }, 'extract a non-array');
+    assert.deepEqual(jsonTransform({ x: '$.foo[0]' })({ foo: [1, 2, 3] }), { x: 1 }, 'extract the first value');
+    assert.deepEqual(jsonTransform({ x: '$.foo[*].bar' })({ foo: [{ bar: 1 }] }), { x: [1] }, 'extract array of deep values');
+    assert.deepEqual(jsonTransform({ x: '$.foo[0].bar' })({ foo: [{ bar: 1 }] }), { x: 1 }, 'extract the first deep value');
+    assert.deepEqual(jsonTransform({ x: '$.foo[0].baz' })({ foo: [{ bar: 1 }] }), { x: null }, 'extract the first deep missing value');
+    assert.deepEqual(jsonTransform({ x: '$.foo[0].baz' })({ foo: [{ bar: 1, baz: [] }] }), { x: [] }, 'extract the first deep empty value');
+    assert.deepEqual(jsonTransform({ x: '$.foo[0].baz[*]' })({ foo: [{ baz: [4] }] }), { x: [4] }, 'extract deep array\'s items');
+    assert.deepEqual(jsonTransform({ x: '$.foo[0].baz[0]' })({ foo: [{ baz: [4] }] }), { x: 4 }, 'extract first of deep array\'s values');
+    // This is a unique case.  Author obviously intends only last item even though this is slice notation:
+    assert.deepEqual(jsonTransform({ x: '$.foo[-1:]' })({ foo: [1,2,3,4] }), { x: 4 }, 'extract last item using slice notation')
+  });
 });


### PR DESCRIPTION
This was eventually going to bite us.  We have probably already been bitten, but haven't noticed it since the json outputs are so huge and numerous.

Before this fix, the code guessed that all single-value arrays returned from jsonpath were intended to be output as scalars, not arrays.  This makes sense since a query such as `"$.ProjectName"` should output a string like `"GC_Default"`, not `["GC_Default"]`.  On the other hand, there are cases where a query returns an array with a single value, but the author intended to output it as an array.  

Note: On the surface, it seemed likely that this fix causes a small performance degradation, but  -- using simple bash commands -- I am finding an unexpected 10% performance increase.  Weird.  

Still, even more performance can be made if the code that guesses author intention runs only once (by pre-processing the template).  I would have done this already, but didn't want to spend the time at this late point.  It would be easy to follow up with a performance PR in the future.